### PR TITLE
Config is deprecated in Ruby 1.9.3 and 1.8.8

### DIFF
--- a/lib/racc/parserfilegenerator.rb
+++ b/lib/racc/parserfilegenerator.rb
@@ -119,7 +119,7 @@ module Racc
       footer
     end
 
-    c = ::Config::CONFIG
+    c = ::RbConfig::CONFIG
     RUBY_PATH = "#{c['bindir']}/#{c['ruby_install_name']}#{c['EXEEXT']}"
 
     def shebang(path)


### PR DESCRIPTION
Use RbConfig to suppress deprecation warnings when generating a parser.

I hope this is the right repository to commit patches to!
