### PR TITLE
Include context in error message

### DIFF
--- a/lib/racc/parser.rb
+++ b/lib/racc/parser.rb
@@ -540,8 +540,12 @@ module Racc
     #
     # If this method returns, parsers enter "error recovering mode".
     def on_error(t, val, vstack)
-      raise ParseError, sprintf("\nparse error on value %s (%s)",
-                                val.inspect, token_to_str(t) || '?')
+      errcontext = (@ss.pre_match[-10..-1] || @ss.pre_match) +
+                    @ss.matched + @ss.post_match[0..9]
+      raise ParseError, sprintf("\nparse error on value %s (%s) " +
+                                "around \"%s\"",
+                                val.inspect, token_to_str(t) || '?',
+                                errcontext)
     end
 
     # Enter error recovering mode.


### PR DESCRIPTION
Currently racc will output something like this on a syntax error:

> parse error on value ";" (SEMI)

which is not very useful if you've got semi-colons on every line of a 100KB file. Since line number and column number are apparently not possible (#15), the next best thing would be to include the context around the error.

With this change, we will now say this:

> parse error on value ";" (SEMI) around "blah.blah.;blah.blah."

(the 10 characters preceding the token, the token, then the 10 characters after the token.)
