### PR TITLE
fix detection of rb_ary_subseq(), use mkmf's have_func()

### DIFF
--- a/ext/racc/cparse.c
+++ b/ext/racc/cparse.c
@@ -80,7 +80,7 @@ static ID id_use_result;
 #  define LONG2NUM(i) INT2NUM(i)
 #endif
 
-#ifndef rb_ary_subseq
+#ifndef HAVE_RB_ARY_SUBSEQ
 #  define rb_ary_subseq(ary, beg, len) rb_ary_new4(len, RARRAY_PTR(ary) + beg)
 #endif
 

--- a/ext/racc/extconf.rb
+++ b/ext/racc/extconf.rb
@@ -1,3 +1,5 @@
 require 'mkmf'
 
+have_func('rb_ary_subseq')
+
 create_makefile 'racc/cparse'


### PR DESCRIPTION
- See tenderlove/racc#34 and 1b1942a0
