### PR TITLE
Add info.rb to embedded output

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -34,14 +34,18 @@ hoe = Hoe.spec 'racc' do
 end
 
 file 'lib/racc/parser-text.rb' => ['lib/racc/parser.rb'] do |t|
+  info = 'lib/racc/info.rb'
   source = 'lib/racc/parser.rb'
 
   open(t.name, 'wb') { |io|
     io.write(<<-eorb)
 module Racc
-  PARSER_TEXT = <<'__end_of_file__'
+  INFO_TEXT = <<'__end_of_info__'
+#{File.read(info)}
+__end_of_info__
+  PARSER_TEXT = <<'__end_of_parser__'
 #{File.read(source)}
-__end_of_file__
+__end_of_parser__
 end
     eorb
   }

--- a/lib/racc/parserfilegenerator.rb
+++ b/lib/racc/parserfilegenerator.rb
@@ -102,6 +102,7 @@ module Racc
       notice
       line
       if @params.embed_runtime?
+        embed_library info_source()
         embed_library runtime_source()
       else
         require 'racc/parser.rb'
@@ -131,6 +132,10 @@ module Racc
 
     def runtime_source
       SourceText.new(::Racc::PARSER_TEXT, 'racc/parser.rb', 1)
+    end
+
+    def info_source
+      SourceText.new(::Racc::INFO_TEXT, 'racc/info.rb', 1)
     end
 
     def embed_library(src)

--- a/lib/racc/pre-setup
+++ b/lib/racc/pre-setup
@@ -3,9 +3,12 @@ def generate_parser_text_rb(target)
   $stderr.puts "generating #{target}..."
   File.open(target, 'w') {|f|
     f.puts "module Racc"
-    f.puts "  PARSER_TEXT = <<'__end_of_file__'"
+    f.puts "  INFO_TEXT = <<'__end_of_info__'"
+    f.puts File.read(srcfile('info.rb'))
+    f.puts "__end_of_info__"
+    f.puts "  PARSER_TEXT = <<'__end_of_parser__'"
     f.puts File.read(srcfile('parser.rb'))
-    f.puts "__end_of_file__"
+    f.puts "__end_of_parser__"
     f.puts "end"
   }
 end


### PR DESCRIPTION
When the embed option (-E) is used, racc adds the contents of `parser.rb` to the output parser so that the parser can be run by itself without requiring racc. But `parser.rb` requires `info.rb`, creating an error when the output parser is run.

These changes add the contents of `info.rb` to the output before the embedded parser. I tried to stick to the  current coding style. The alternative (and cleaner) solution is to just code the version info directly into `parser.rb`. This was the solution prior to b20632d3d5bea5cabddb0622fe3baaa9712258ff.

I made this pull request to the 1-4-stable branch because I'm not sure of the status of master.
