### PR TITLE
Make generated action and goto tables identical on Ruby 2.1/2.2

### DIFF
--- a/lib/racc/statetransitiontable.rb
+++ b/lib/racc/statetransitiontable.rb
@@ -229,9 +229,16 @@ module Racc
       map = '-' * 10240
 
       # sort long to short
-      entries.sort! {|a,b| b[0].size <=> a[0].size }
+      # we want a stable sort, so that the output will not be dependent on
+      # the sorting algorithm used by the underlying Ruby implementation
+      entries.each_with_index.map { |a, i| a.unshift(i) }
+      entries.sort! do |a, b|
+        comp = (b[1].size <=> a[1].size)
+        comp = (a[0] <=> b[0]) if comp == 0
+        comp
+      end
 
-      entries.each do |arr, chkval, expr, min, ptri|
+      entries.each do |_, arr, chkval, expr, min, ptri|
         if upper + arr.size > map.size
           map << '-' * (arr.size + 1024)
         end


### PR DESCRIPTION
In git commit a8994b16, Nobuyoshi Nakada made MRI use qsort_r as its underlying
sorting implementation on platforms which have it. This change of sort function
means that in cases where an array has equal sort keys, the sort order will
usually be different between 2.1 and 2.2.

StateTransitionTableGenerator uses Array#sort! to order entries which are
being inserted into one of the generated tables. Many entries have equal
sort keys, so the difference in sort order means the generated tables are not
identical between 2.1 and 2.2.

Therefore, add an extra sort key as a "tie-breaker", so the sort order is
completely deterministic regardless of the underlying sorting function. This
will help Racc to generate completely identical parser code, regardless of the
Ruby interpreter being used.