### PR TITLE
[Bugfix] Don't infinite-loop if error recovery is attempted at EOF

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -61,6 +61,7 @@ test/assets/conf.y
 test/assets/digraph.y
 test/assets/echk.y
 test/assets/err.y
+test/assets/error_recovery.y
 test/assets/expect.y
 test/assets/firstline.y
 test/assets/ichk.y

--- a/lib/racc/parser.rb
+++ b/lib/racc/parser.rb
@@ -396,7 +396,7 @@ puts $!.backtrace
         # shift
         #
         if @racc_error_status > 0
-          @racc_error_status -= 1 unless @racc_t == 1   # error token
+          @racc_error_status -= 1 unless @racc_t <= 1 # error token or EOF
         end
         @racc_vstack.push @racc_val
         @racc_state.push act
@@ -445,6 +445,8 @@ puts $!.backtrace
           end
         when 3
           if @racc_t == 0   # is $
+            # We're at EOF, and another error occurred immediately after
+            # attempting auto-recovery
             throw :racc_end_parse, nil
           end
           @racc_read_next = true

--- a/test/assets/error_recovery.y
+++ b/test/assets/error_recovery.y
@@ -1,0 +1,35 @@
+# Regression test case for the bug discussed here:
+# https://github.com/whitequark/parser/issues/93
+# In short, a Racc-generated parser could go into an infinite loop when
+# attempting error recovery at EOF
+
+class InfiniteLoop
+
+rule
+
+  stmts: stmt
+       | error stmt
+
+  stmt: '%' stmt
+
+end
+
+---- inner
+
+  def parse
+    @errors = []
+    do_parse
+  end
+
+  def next_token
+    nil
+  end
+
+  def on_error(error_token, error_value, value_stack)
+    # oh my, an error
+    @errors << [error_token, error_value]
+  end
+
+---- footer
+
+InfiniteLoop.new.parse

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -3,6 +3,7 @@ require 'minitest/autorun'
 require 'racc/static'
 require 'fileutils'
 require 'tempfile'
+require 'timeout'
 
 module Racc
   class TestCase < MiniTest::Unit::TestCase

--- a/test/test_racc_command.rb
+++ b/test/test_racc_command.rb
@@ -151,5 +151,14 @@ module Racc
         assert_compile 'unterm.y'
       }
     end
+
+    # Regression test for a problem where error recovery at EOF would cause
+    # a Racc-generated parser to go into an infinite loop (on some grammars)
+    def test_error_recovery_y
+      assert_compile 'error_recovery.y'
+      Timeout.timeout(10) do
+        assert_exec 'error_recovery.y'
+      end
+    end
   end
 end


### PR DESCRIPTION
There is a well-known bug with Racc which often makes it 'hang' when an error
occurs in the input. For example, the bug is discussed here:

https://github.com/whitequark/parser/issues/93

The problem occurs when error recovery is attempted at EOF. To avoid an infinite
loop, error recovery should always 1) consume some of the input by shifting, or
2) consume some of the stack by reducing. Normally, Racc's error recovery does
number 1. In this way, if it gets into a loop of hitting an error, trying to
recover, then hitting another error indefinitely, it should eventually run out
of input and stop.

Except... Racc's code for getting a token from the input has a guard clause
which makes it do nothing when at EOF. Makes sense, but the code for shifting
*still* behaves as if a token had been successfully consumed and decrements
`@racc_error_status`.

When error recovery is entered again, it aborts the parse if at EOF... but only
if `@racc_error_status == 3`. In other words: only if no token was successfully
shifted since the last error was hit.

This easily leads to an infinite loop where Racc hits an error at EOF, tries
error recovery, pops a state off the stack and goes back to the previous state,
tries to continue the parse, tries to shift (but gets nothing because of EOF),
the shifting code still looks up the next state in its action table and pushes
it on the stack (restoring the state which the error recovery code discarded),
hits another error, tries to recover, and so on ad infinitum.

To avoid this, do not decrement `@racc_error_status` on shifting, if the 'shift'
didn't actually shift anything due to being at EOF. I am almost certain that
this is what the original author actually intended.