### PR TITLE
Add appropriate license header to Cparse.java

### DIFF
--- a/ext/racc/com/headius/racc/Cparse.java
+++ b/ext/racc/com/headius/racc/Cparse.java
@@ -1,3 +1,17 @@
+/*
+    Cparse.java -- Racc Runtime Core for JRuby
+    
+    Copyright (c) 2016 Charles Oliver Nutter <headius@headius.com>
+    
+    Ported from and distributed under the same licence as cparse.c
+    
+    cparse.c -- Racc Runtime Core
+  
+    Copyright (c) 1999-2006 Minero Aoki
+  
+    This library is free software.
+    You can distribute/modify this program under the same terms of ruby.
+*/
 package com.headius.racc;
 
 import org.jruby.Ruby;


### PR DESCRIPTION
Cparse.java, as a port of cparse.c, is also licensed under the terms of Ruby itself.

See jruby/jruby#4603.