### PR TITLE
Fix compiling native extension on trunk

### DIFF
--- a/ext/racc/depend
+++ b/ext/racc/depend
@@ -1,1 +1,1 @@
-cparse.o: cparse.c $(hdrdir)/ruby.h $(topdir)/config.h $(hdrdir)/defines.h
+cparse.o: cparse.c $(hdrdir)/ruby/ruby.h $(topdir)/config.h $(hdrdir)/ruby/defines.h


### PR DESCRIPTION
Fix #100

Compiling racc has been failing since ruby/ruby@3d1c86a.

I guess it does not break backward compatibility because the commit message says "Moving public headers was 12-years ago". 