### PR TITLE
Fix Ruby version in GitHub Actions workflow to avoid errors during setup

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@f26937343756480a8cb3ae1f623b9c8d89ed6984 # v1.196.0
         with:
-          ruby-version: "3.4"
+          ruby-version: "3.3" # TODO: Temporarily avoids the error if 3.4 is specified. (https://github.com/ruby/racc/actions/runs/18798977070/job/53643662504)
           bundler-cache: true
       - name: Setup Pages
         id: pages


### PR DESCRIPTION
```
Error: Error: Unavailable version 3.4.0-preview2 for ruby on ubuntu-24.04
          You can request it at https://github.com/ruby/setup-ruby/issues
          Cause: Unexpected HTTP response: 404
    at /home/runner/work/_actions/ruby/setup-ruby/f26937343756480a8cb3ae1f623b9c8d89ed6984/dist/index.js:65021:15
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async body (/home/runner/work/_actions/ruby/setup-ruby/f26937343756480a8cb3ae1f623b9c8d89ed6984/dist/index.js:353:14)
```

see: https://github.com/ruby/racc/actions/runs/18798977070/job/53643662504