### PR TITLE
Fix embedded parser redefinition warnings

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -34,7 +34,7 @@ file 'lib/racc/parser-text.rb' => ['lib/racc/parser.rb', 'lib/racc/info.rb', __F
     lib = $1
     code = File.read("lib/#{lib}.rb")
     code.sub!(/\A(?:#.*\n)+/, '')
-    %[unless $".find {|p| p.end_with?('/#{lib}.rb')}\n$".push "\#{__dir__}/#{lib}.rb"\n#{code}\nend\n]
+    %[unless $".find {|p| p.tr('\\\\', '/').end_with?('/#{lib}.rb')}\n$".push "\#{__dir__}/#{lib}.rb"\n#{code}\nend\n]
   rescue
     $&
   end

--- a/lib/racc/parserfilegenerator.rb
+++ b/lib/racc/parserfilegenerator.rb
@@ -138,7 +138,7 @@ module Racc
 
     def embed_library(src)
       line %[###### #{src.filename} begin]
-      line %[unless $".find {|p| p.end_with?('/#{src.filename}')}]
+      line %[unless $".find {|p| p.tr('\\\\', '/').end_with?('/#{src.filename}')}]
       line %[$".push "\#{__dir__}/#{src.filename}"]
       put src, @params.convert_line?
       line %[end]

--- a/test/test_parser_text.rb
+++ b/test/test_parser_text.rb
@@ -4,7 +4,17 @@ module Racc
   class TestRaccParserText < TestCase
     def test_parser_text_require
       assert_not_match(/^require/, Racc::PARSER_TEXT)
-      assert_in_out_err(%W[-I#{LIB_DIR} -rracc/parser-text -e$:.clear -eeval(Racc::PARSER_TEXT)])
+      ruby "-I#{LIB_DIR}", "-rracc/parser-text", "-e", "$:.clear", "-e", "eval(Racc::PARSER_TEXT)", quiet: true
+    end
+
+    def test_parser_text_require_with_backslash_loaded_feature
+      ruby "-I#{LIB_DIR}", "-rracc/parser-text", "-e", <<~'RUBY', quiet: true
+        require 'racc/info'
+        $".map! do |feature|
+          feature.end_with?('/racc/info.rb') ? 'C:\\tmp\\racc\\info.rb' : feature
+        end
+        eval(Racc::PARSER_TEXT)
+      RUBY
     end
   end
 end

--- a/test/test_racc_command.rb
+++ b/test/test_racc_command.rb
@@ -48,6 +48,17 @@ module Racc
       assert_exec 'echk.y', quiet: true
     end
 
+    def test_echk_y_with_backslash_loaded_feature
+      assert_compile 'echk.y', '-E'
+      assert_debugfile 'echk.y', []
+      ruby "-I#{LIB_DIR}", "-rracc/parser", "-e", <<~'RUBY', "#{@TAB_DIR}/echk", quiet: true
+        $".map! do |feature|
+          feature.end_with?('/racc/parser.rb') ? 'C:\\tmp\\racc\\parser.rb' : feature
+        end
+        load ARGV.shift
+      RUBY
+    end
+
     def test_err_y
       assert_compile 'err.y'
       assert_debugfile 'err.y', []


### PR DESCRIPTION
Fix embedded parser runtime guards so they do not reload embedded files when `$LOADED_FEATURES` contains Windows-style backslash paths.